### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,5 @@
 :spring_boot_version: 1.5.10.RELEASE
-:jdk: http://www.oracle.com/technetwork/java/javase/downloads/index.html
+:jdk: https://www.oracle.com/technetwork/java/javase/downloads/index.html
 :gs-maven: link:/guides/gs/maven
 :gs-gradle: link:/guides/gs/gradle
 :gs-consuming-rest: link:/guides/gs/consuming-rest
@@ -18,7 +18,7 @@ You'll pick a Spring guide and import it into Spring Tool Suite. Then you can re
 == What you'll need
 
  - About 15 minutes
- - http://spring.io/tools/sts/all[Spring Tool Suite (STS)]
+ - https://spring.io/tools/sts/all[Spring Tool Suite (STS)]
  - {jdk}[JDK 8] or later
 
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).
* [ ] http://spring.io/tools/sts/all with 1 occurrences migrated to:  
  https://spring.io/tools/sts/all ([https](https://spring.io/tools/sts/all) result 200).
* [ ] http://www.oracle.com/technetwork/java/javase/downloads/index.html with 1 occurrences migrated to:  
  https://www.oracle.com/technetwork/java/javase/downloads/index.html ([https](https://www.oracle.com/technetwork/java/javase/downloads/index.html) result 200).