### PR TITLE
Fix broken Spring Tool Suite link

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -19,7 +19,7 @@ You'll pick a Spring guide and import it into Spring Tool Suite. Then you can re
 == What you'll need
 
  - About 15 minutes
- - http://spring.io/tools/sts/all[Spring Tool Suite (STS)]
+ - https://spring.io/tools[Spring Tool Suite (STS)]
  - {jdk}[JDK 8] or later
 
 


### PR DESCRIPTION
The link to the Spring Tool Suite used in this article is outdated and leads to a 404 page. This PR replaces the link with a link to the general STS page which offers the required download options. It also uses HTTPS instead of HTTP.

@pivotal-cla This is an obvious fix